### PR TITLE
Update the baseline model and simplify dataloader

### DIFF
--- a/src/utilities/data/aircraft_dataloader.py
+++ b/src/utilities/data/aircraft_dataloader.py
@@ -1,0 +1,62 @@
+import torch
+from torch.utils.data import DataLoader
+from torchvision import transforms
+
+from src.utilities.data.aircraft_dataset import AircraftDataset
+
+
+def collate_fn(
+  batch: list
+  ) -> tuple:
+  """The collation function for batching in the DataLoader"""
+  images, counts = zip(*batch)
+  images = torch.stack(images, dim=0)
+  counts = torch.stack(counts, dim=0)
+  return images, counts
+
+def get_dataloader(
+  image_dir: str,
+  labels_fp: str,
+  transformations: transforms.Compose = None,
+  mode: str = "train",
+  train_frac: float = 0.8,
+  val_frac: float = 0.1,
+  seed: int = 2020,  
+  batch_size: int = 8,
+  shuffle: bool = True,
+  num_workers: int = 2
+) -> torch.utils.data.DataLoader:
+  """
+  Creates and returns a PyTorch DataLoader for the Aircraft Count dataset.
+
+  Args:
+    image_dir: The path to the directory containing the images.
+    labels_fp: The filepath to the CSV file containing labels (counts).
+    transformations: A list of callable transformations (e.g., from Albumentations).
+    batch_size: The number of samples per batch.
+    shuffle: Whether to shuffle the dataset.
+    num_workers: The number of subprocesses to use for data loading.
+
+  Returns:
+    A PyTorch DataLoader.
+  """
+
+  dataset = AircraftDataset(
+    image_dir=image_dir,
+    labels_fp=labels_fp,
+    transformations=transformations,
+    mode=mode,
+    train_frac=train_frac,
+    val_frac=val_frac,
+    seed=seed,
+  )
+
+  dataloader = DataLoader(
+    dataset,
+    batch_size=batch_size,
+    shuffle=shuffle,
+    num_workers=num_workers,
+    collate_fn=collate_fn
+  )
+
+  return dataloader

--- a/src/utilities/data/aircraft_dataset.py
+++ b/src/utilities/data/aircraft_dataset.py
@@ -1,0 +1,108 @@
+import os
+from glob import glob
+from typing import List, Callable
+
+import torch
+import pandas as pd
+import numpy as np
+import albumentations as A
+from torch.utils.data import Dataset
+from albumentations.pytorch import ToTensorV2
+from PIL import Image
+
+
+class AircraftDataset(Dataset):
+  """
+  Custom Dataset class for the Aircraft Images dataset.
+  """
+
+  def __init__(
+    self,
+    image_dir: str,
+    labels_fp: str,
+    transformations: List[Callable] = None,
+    mode: str = "train",
+    train_frac: float = 0.8,
+    val_frac: float = 0.1,
+    seed: int = 2020,  
+  ) -> None:
+    """
+    Initializes the dataset.
+
+    Args:
+      image_dir: The path to the directory containing the images
+      labels_fp: The filepath to the CSV file containing labels and geometry info.
+      transformations: A list of transformations to apply to the images and geometry.
+    """
+    if mode not in ["train", "val", "test"]:
+      raise ValueError("Invalid mode. Must be one of 'train', 'val', or 'test'.")
+    if train_frac + val_frac >= 1:
+      raise ValueError("train_frac + val_frac must be less than 1.")
+    
+    if not transformations:
+      transformations = A.Compose([
+        ToTensorV2(),
+      ])
+    self.image_filepaths = list(sorted(glob(os.path.join(image_dir, "*.jpg"))))  # get all files with the .jpg extension
+    np.random.seed(seed)
+    np.random.shuffle(self.image_filepaths)
+
+    # Split the dataset into train, validation, and test sets
+    num_images = len(self.image_filepaths)
+    train_end = int(train_frac * num_images)
+    val_end = train_end + int(val_frac * num_images)
+    
+    self.train_image_filepaths = self.image_filepaths[:train_end]
+    self.val_image_filepaths = self.image_filepaths[train_end:val_end]
+    self.test_image_filepaths = self.image_filepaths[val_end:]
+
+    self.labels_df = pd.read_csv(labels_fp, converters={'geometry':lambda x:list(eval(x))})  # parse the list of tuples from string literal
+
+    self.transformations = transformations
+
+    # Create a mapping from image filename to index for efficient lookup
+    self.filename_to_index = {os.path.basename(fp): i for i, fp in enumerate(self.train_image_filepaths + self.val_image_filepaths + self.test_image_filepaths)}
+
+    self.mode = mode
+
+  def __len__(self):
+    """
+    Returns the total number of samples in the dataset.
+    """
+    if self.mode == "train":
+      return len(self.train_image_filepaths)
+    elif self.mode == "val":
+      return len(self.val_image_filepaths)
+    else:
+      return len(self.test_image_filepaths)
+
+  def __getitem__(self, idx):
+    """
+    Loads and returns a sample from the dataset at the given index.
+    """
+    if self.mode == "train":
+      img_path = self.train_image_filepaths[idx]
+    elif self.mode == "val":
+      img_path = self.val_image_filepaths[idx]
+    else:
+      img_path = self.test_image_filepaths[idx]
+    img_name = os.path.basename(img_path)
+
+    # Load image
+    image = Image.open(img_path).convert("RGB")
+
+    # Get count of aircraft for the current image
+    annotations = self.labels_df[(self.labels_df['image_id'] == img_name) & (self.labels_df['class'] == "Airplane")]
+    count = len(annotations)
+
+    # Convert count to a PyTorch tensor
+    count = torch.tensor(count, dtype=torch.float32)  # Use float for regression
+
+    # Convert PIL Image to NumPy array
+    image = np.array(image)
+
+    # Apply transformations if any
+    if self.transformations:
+      image = self.transformations(image=image)['image']
+
+    return image, count


### PR DESCRIPTION
## Summary of core changes:

* Update the baseline model to an MLP from a CNN
* Refactor the `Dataset` and `Dataloader` to be deterministic
* Enforce standard `train`, `val`, and `test` sets given a `seed`, `train_frac`, and `val_frac`
* Basic metrics for comparisons between models

## Future improvements:

* Create a dedicated notebook and associated utilities for training, evaluating, and comparing `(model, transformations)` pairs